### PR TITLE
fix: Replace hardcoded path with placeholder in starforge update

### DIFF
--- a/bin/starforge
+++ b/bin/starforge
@@ -153,7 +153,7 @@ case "$COMMAND" in
 
         # Update settings with path replacement
         echo -e "${INFO}Updating settings.json..."
-        sed "s|/Users/krunaaltavkar/empowerai|$TARGET_DIR|g" "$STARFORGE_DIR/templates/settings/settings.json" > "$CLAUDE_DIR/settings.json"
+        sed "s|{{PROJECT_DIR}}|$TARGET_DIR|g" "$STARFORGE_DIR/templates/settings/settings.json" > "$CLAUDE_DIR/settings.json"
         echo -e "${CHECK} Updated settings.json"
 
         echo ""


### PR DESCRIPTION
## Summary

Fixes hardcoded `/Users/krunaaltavkar/empowerai` path in `bin/starforge:156` that broke project-agnostic design.

## Problem

- Line 156 used hardcoded absolute path: `/Users/krunaaltavkar/empowerai`
- This path doesn't exist on other machines, breaking `starforge update`
- Template file already uses `{{PROJECT_DIR}}` placeholder correctly
- Scanner detected violation during cleanup audit

## Solution

Changed sed replacement pattern:
```bash
# Before (broken)
sed "s|/Users/krunaaltavkar/empowerai|$TARGET_DIR|g"

# After (correct)
sed "s|{{PROJECT_DIR}}|$TARGET_DIR|g"
```

Now correctly replaces the placeholder that exists in the template.

## Testing

- Hardcoded pattern scanner: PASS (no /Users/ violations in line 156)
- Settings template tests: PASS (placeholder replacement works)
- Verified manually that template has `{{PROJECT_DIR}}` placeholder

## Test Plan

- [x] Run hardcoded pattern scanner on bin/starforge
- [x] Run test_settings_template.sh
- [x] Verify sed pattern matches template structure
- [x] Confirm no other hardcoded paths in update logic

## Related

- Part of project-agnostic refactor effort
- Similar fix to PR #98 (templates/LEARNINGS.md)
- Discovered during agent definition cleanup

## Impact

- Low risk: Simple one-line change
- High value: Fixes broken update command on new installations
- No breaking changes: Only affects update logic, not existing installs

Generated with [Claude Code](https://claude.com/claude-code)