### PR TITLE
fix: Skip directories when copying hooks to prevent deployment failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@
 *.log
 .claude/
 
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
 # Environment files (but keep template)
 .env
 !.env.example

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -232,8 +232,8 @@ copy_agent_files() {
     cp "$TEMPLATE_DIR/scripts"/*.sh "$CLAUDE_DIR/scripts/"
     chmod +x "$CLAUDE_DIR/scripts"/*.sh
 
-    # Copy hooks (all files, not just .sh)
-    cp "$TEMPLATE_DIR/hooks"/* "$CLAUDE_DIR/hooks/"
+    # Copy hooks (all files, skip directories like __pycache__)
+    find "$TEMPLATE_DIR/hooks" -maxdepth 1 -type f -exec cp {} "$CLAUDE_DIR/hooks/" \;
     chmod +x "$CLAUDE_DIR/hooks"/*.sh "$CLAUDE_DIR/hooks"/*.py 2>/dev/null || true
 
     # Copy lib files

--- a/bin/starforge
+++ b/bin/starforge
@@ -139,9 +139,9 @@ case "$COMMAND" in
         chmod +x "$CLAUDE_DIR/scripts"/*.sh
         echo -e "${CHECK} Updated scripts"
 
-        # Update hooks (copy all files, not just .sh)
+        # Update hooks (copy all files, skip directories like __pycache__)
         echo -e "${INFO}Updating hooks..."
-        cp "$STARFORGE_DIR/templates/hooks"/* "$CLAUDE_DIR/hooks/"
+        find "$STARFORGE_DIR/templates/hooks" -maxdepth 1 -type f -exec cp {} "$CLAUDE_DIR/hooks/" \;
         chmod +x "$CLAUDE_DIR/hooks"/*.sh "$CLAUDE_DIR/hooks"/*.py 2>/dev/null || true
         echo -e "${CHECK} Updated hooks"
 


### PR DESCRIPTION
## Problem

PR #146 added logic to deploy Discord webhook files, but `starforge update` was failing to deploy `.env.example` due to a critical bug:

**Error encountered:**
```bash
cp: -r not specified; omitting directory '/Users/.../templates/hooks/__pycache__'
```

**Root cause:**
- The `cp` command in both `bin/starforge` and `bin/install.sh` uses `cp templates/hooks/* ...`
- When Python bytecode directories like `__pycache__/` exist, `cp` fails (can't copy directories without `-r`)
- Due to `set -e`, the script aborts immediately
- `.env.example` copy logic never executes
- Users don't receive Discord webhook configuration template

## Solution

Replace glob-based `cp` with `find` to copy only files:

```bash
# Before (fails on directories)
cp "$STARFORGE_DIR/templates/hooks"/* "$CLAUDE_DIR/hooks/"

# After (skips directories)
find "$STARFORGE_DIR/templates/hooks" -maxdepth 1 -type f -exec cp {} "$CLAUDE_DIR/hooks/" \;
```

## Changes

### bin/starforge (update command)
- ✅ Use `find -type f` to copy only hook files
- ✅ Skip directories like `__pycache__/`
- ✅ Update comment to clarify behavior

### bin/install.sh (install command)
- ✅ Use `find -type f` to copy only hook files
- ✅ Skip directories like `__pycache__/`
- ✅ Update comment to clarify behavior

### .gitignore
- ✅ Add Python artifacts section
- ✅ Ignore `__pycache__/`, `*.pyc`, `*.pyo`, etc.
- ✅ Prevent Python bytecode from being committed

## Testing

Created test scenario with `__pycache__/` directory in `templates/hooks/`:

```bash
# Create test __pycache__
mkdir -p templates/hooks/__pycache__
echo "test" > templates/hooks/__pycache__/test.pyc

# Remove .env.example to test deployment
rm .env.example

# Run update
starforge update
```

**Result:**
```
✅ Updated hooks
✅ Added .env.example (configure for Discord notifications)
```

**Verified:**
- ✅ No errors about `__pycache__`
- ✅ `.env.example` deployed successfully
- ✅ `stop.py` deployed with Discord code
- ✅ All hook files copied correctly

## Impact

**Before this fix:**
- Users running `starforge update` would NOT receive Discord webhook integration
- `.env.example` would NOT be deployed
- Update would silently fail partway through

**After this fix:**
- ✅ Deployment completes successfully even with Python artifacts
- ✅ `.env.example` deployed to all users
- ✅ Discord webhook integration fully functional
- ✅ Robust against future directory artifacts

## Related

- Fixes deployment issues from PR #146 (Discord webhook integration)
- Ensures PR #144 features actually reach users

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>