### PR TITLE
fix: Add missing tools to permissions allow list

### DIFF
--- a/templates/settings/settings.json
+++ b/templates/settings/settings.json
@@ -4,9 +4,14 @@
       "Read",
       "Write",
       "Edit",
+      "MultiEdit",
       "Grep",
       "Glob",
-      "Bash"
+      "LS",
+      "Bash",
+      "WebSearch",
+      "WebFetch",
+      "Task"
     ],
     "deny": [
       "Write(/etc/**)",


### PR DESCRIPTION
## Summary
Adds 5 tools that were accidentally omitted from PR #196

## Missing Tools Added
- **MultiEdit** - Batch file editing
- **LS** - Directory listing  
- **Task** - Sub-agent invocation (critical for parallel work)
- **WebSearch** - Web searching
- **WebFetch** - Web content fetching

## Why This Matters
Without these tools, agents will still get permission prompts for:
- Invoking sub-agents (Task)
- Web research (WebSearch/WebFetch)
- Directory listings (LS)
- Batch edits (MultiEdit)

This blocks autonomous execution.

## Changes
```diff
"allow": [
  "Read",
  "Write",
  "Edit",
+ "MultiEdit",
  "Grep",
  "Glob",
+ "LS",
  "Bash",
+ "WebSearch",
+ "WebFetch",
+ "Task"
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)