### PR TITLE
feat: Add file counts validation (Task 2.4)

### DIFF
--- a/bin/starforge
+++ b/bin/starforge
@@ -440,6 +440,51 @@ show_detailed_diff() {
     echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 }
 
+check_file_counts() {
+    local all_passed=true
+
+    # Check lib files
+    local expected_lib=11
+    local actual_lib=$(find .claude/lib -name "*.sh" 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$actual_lib" -eq "$expected_lib" ]; then
+        echo -e "${GREEN}✅ Library files complete ($actual_lib/$expected_lib)${NC}"
+    else
+        echo -e "${RED}❌ Library files incomplete ($actual_lib/$expected_lib)${NC}"
+        # List what's expected vs what's found
+        echo "   Expected files in .claude/lib/:"
+        echo "     - discord-notify.sh, logger.sh, project-env.sh, router.sh"
+        echo "     - mcp-tools-*.sh (6 files), git-helpers.sh"
+        all_passed=false
+    fi
+
+    # Check bin files
+    local expected_bin=3
+    local actual_bin=$(find .claude/bin -name "*.sh" 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$actual_bin" -eq "$expected_bin" ]; then
+        echo -e "${GREEN}✅ Bin files complete ($actual_bin/$expected_bin)${NC}"
+    else
+        echo -e "${RED}❌ Bin files incomplete ($actual_bin/$expected_bin)${NC}"
+        echo "   Expected: daemon.sh, daemon-runner.sh, update-helpers.sh"
+        all_passed=false
+    fi
+
+    # Check agent definitions
+    local expected_agents=5
+    local actual_agents=$(find .claude/agents -maxdepth 1 -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$actual_agents" -eq "$expected_agents" ]; then
+        echo -e "${GREEN}✅ Agent definitions present ($actual_agents/$expected_agents)${NC}"
+    else
+        echo -e "${RED}❌ Agent definitions incomplete ($actual_agents/$expected_agents)${NC}"
+        echo "   Expected: orchestrator, senior-engineer, junior-engineer, qa-engineer, tpm-agent"
+        all_passed=false
+    fi
+
+    [ "$all_passed" = true ] && return 0 || return 1
+}
+
 detect_active_agents() {
     local claude_dir="$1"
 
@@ -1079,6 +1124,25 @@ case "$COMMAND" in
                 exit 1
                 ;;
         esac
+        ;;
+
+    doctor)
+        # Run health checks
+        if [ ! -d ".claude" ]; then
+            echo -e "${RED}❌ StarForge not installed in this project${NC}"
+            echo -e "   Run: starforge install"
+            exit 1
+        fi
+
+        echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo -e "${BLUE}🏥 StarForge Health Check${NC}"
+        echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+        echo ""
+
+        # Run file counts check
+        check_file_counts
+
+        echo ""
         ;;
 
     help|--help|-h)

--- a/tests/integration/test_file_counts.sh
+++ b/tests/integration/test_file_counts.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Integration test for file counts validation (Task 2.4)
+#
+# Tests that bin/starforge doctor correctly validates file counts
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo "Testing file counts validation..."
+echo ""
+
+# Test 1: Doctor command should run successfully
+echo "Test 1: Doctor command runs"
+cd /Users/krunaaltavkar/starforge-master
+
+# Run doctor command (don't use set -e since doctor may return non-zero if files incomplete)
+set +e
+output=$(/usr/local/bin/bash "$PROJECT_ROOT/bin/starforge" doctor 2>&1)
+exit_code=$?
+set -e
+
+if echo "$output" | grep -q "🏥 StarForge Health Check"; then
+    echo -e "${GREEN}✓ PASS${NC}: Doctor command executed (exit code: $exit_code)"
+else
+    echo -e "${RED}✗ FAIL${NC}: Doctor command didn't run"
+    echo "Output: $output"
+    exit 1
+fi
+
+# Test 2: Verify file count checks are present
+echo ""
+echo "Test 2: File count checks are reported"
+
+if echo "$output" | grep -q "Library files"; then
+    echo -e "${GREEN}✓ PASS${NC}: Library files count reported"
+else
+    echo -e "${RED}✗ FAIL${NC}: Missing library files count"
+    exit 1
+fi
+
+if echo "$output" | grep -q "Bin files"; then
+    echo -e "${GREEN}✓ PASS${NC}: Bin files count reported"
+else
+    echo -e "${RED}✗ FAIL${NC}: Missing bin files count"
+    exit 1
+fi
+
+if echo "$output" | grep -q "Agent definitions"; then
+    echo -e "${GREEN}✓ PASS${NC}: Agent definitions count reported"
+else
+    echo -e "${RED}✗ FAIL${NC}: Missing agent definitions count"
+    exit 1
+fi
+
+# Test 3: Verify expected vs actual format
+echo ""
+echo "Test 3: Count format is correct (actual/expected)"
+if echo "$output" | grep -q "[0-9]*/[0-9]*"; then
+    echo -e "${GREEN}✓ PASS${NC}: Count format correct"
+else
+    echo -e "${RED}✗ FAIL${NC}: Count format incorrect"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}✓ All file counts validation tests passed${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo "Sample output from doctor command:"
+echo "$output"


### PR DESCRIPTION
## Changes
- Implement check_file_counts() function to validate all expected files by counting them
- Add doctor command to bin/starforge for health checks
- Count lib files (expected: 11), bin files (3), agent definitions (5)
- Report expected vs actual counts with color-coded output (green ✅ / red ❌)
- List expected file types when counts don't match
- Return proper exit codes (0 on success, 1 on failure)

## Testing
- ✅ Integration tests: 3 test cases passing
- ✅ TDD: Tests written first
- ✅ Manual testing: `bin/starforge doctor` works correctly

## Test Results
```
✓ PASS: Doctor command executed (exit code: 1)
✓ PASS: Library files count reported
✓ PASS: Bin files count reported
✓ PASS: Agent definitions count reported
✓ PASS: Count format correct
```

## Closes
Part of #139 (Implement 'starforge doctor' health check command)