### PR TITLE
fix: Correct claude CLI invocation in daemon-runner.sh

### DIFF
--- a/templates/bin/daemon-runner.sh
+++ b/templates/bin/daemon-runner.sh
@@ -237,9 +237,9 @@ invoke_agent() {
   MONITOR_PID=$!
 
   # Invoke agent via MCP server (no TTY required)
-  # MCP server pipes JSON-RPC to claude --mcp stdio
+  # MCP server pipes JSON-RPC to claude stdin
   if timeout "$AGENT_TIMEOUT" "$CLAUDE_DIR/bin/mcp-server.sh" | claude \
-    --mcp stdio \
+    --print \
     --permission-mode bypassPermissions \
     "Use the $to_agent agent. $prompt" >> "$LOG_FILE" 2>&1; then
     local duration=$(($(date +%s) - start_time))
@@ -695,7 +695,7 @@ orchestrator_check() {
     # Invoke orchestrator via MCP server (no TTY required)
     # IMPORTANT: Use imperative prompt - orchestrator is running autonomously in daemon mode
     if "$CLAUDE_DIR/bin/mcp-server.sh" | claude \
-      --mcp stdio \
+      --print \
       --permission-mode bypassPermissions "You are the orchestrator agent running in AUTONOMOUS DAEMON MODE.
 
 CRITICAL: All permissions are PRE-APPROVED. Execute commands IMMEDIATELY without asking for confirmation or listing what you plan to do.


### PR DESCRIPTION
## Summary

Fixes critical bug in daemon-runner.sh that uses invalid claude CLI flags.

## Problem

`daemon-runner.sh` uses `--mcp stdio` flag in two locations (lines 241-244 and 697-699) which doesn't exist in claude CLI, causing daemon agent invocation to fail.

## Solution

- Remove invalid `--mcp stdio` flag
- Add required `--print` flag for non-interactive execution
- Updated comments to reflect correct behavior

## Testing

Validated via Test 0.3.4 (CLI Parameter Validation):
- ✅ Piping MCP to stdin works
- ✅ --print flag enables non-interactive mode
- ✅ --permission-mode bypassPermissions suppresses prompts
- ✅ File creation successful

**Test command:**
```bash
.claude/bin/mcp-server.sh | claude --print \
  --permission-mode bypassPermissions \
  "Create test.txt"
```

**Result:** File created successfully

## Changes

**Before:**
```bash
.claude/bin/mcp-server.sh | claude \
  --mcp stdio \              # ❌ Invalid flag
  --permission-mode bypassPermissions \
  "Prompt..."
```

**After:**
```bash
.claude/bin/mcp-server.sh | claude \
  --print \                  # ✅ Correct flag
  --permission-mode bypassPermissions \
  "Prompt..."
```

## Locations Fixed

1. **Line 241-244** - `invoke_agent` function: Fixed agent invocation
2. **Line 697-699** - `orchestrator_check` function: Fixed orchestrator periodic check

## Impact

- **Critical:** Daemon agent invocation will now work
- **Required for:** Autonomous 24/7 agent execution
- **No breaking changes:** Only fixes broken functionality

## Related

- Test 0 validation: daemon-TEST-0-RESULTS.md
- Based on claude CLI help output verification
- Prerequisite for Test 1.1 (Daemon Lifecycle)

## Checklist

- [x] Code fixed (--mcp stdio → --print in 2 locations)
- [x] Validated with Test 0.3.4
- [x] No breaking changes
- [x] Commit message explains issue and fix
- [x] Syntax verified with bash -n
- [x] PR describes problem and solution

🤖 Generated with [Claude Code](https://claude.com/claude-code)