### PR TITLE
fix: Move log_event function definition before first use in daemon-runner.sh

### DIFF
--- a/templates/bin/daemon-runner.sh
+++ b/templates/bin/daemon-runner.sh
@@ -34,6 +34,19 @@ mkdir -p "$CLAUDE_DIR/daemon"
 # Touch log file
 touch "$LOG_FILE"
 
+#━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Logging
+#━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+log_event() {
+  local level=$1
+  local message=$2
+  local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  echo "[$timestamp] $level: $message" >> "$LOG_FILE"
+  echo "[$timestamp] $level: $message" >&2
+}
+
 # Load environment variables (Discord webhooks, etc.)
 if [ -f "$PROJECT_ROOT/.env" ]; then
   source "$PROJECT_ROOT/.env"
@@ -60,19 +73,6 @@ if [ "$PARALLEL_DAEMON" = "true" ]; then
     PARALLEL_DAEMON=false
   fi
 fi
-
-#━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# Logging
-#━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-log_event() {
-  local level=$1
-  local message=$2
-  local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-  echo "[$timestamp] $level: $message" >> "$LOG_FILE"
-  echo "[$timestamp] $level: $message" >&2
-}
 
 #━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # State Management


### PR DESCRIPTION
## Summary
Fixes critical bug in daemon startup where `log_event` function was called before being defined.

## Problem
The `log_event` function was being called at line 59 before it was defined at line 68, causing the daemon to fail to start with:
```
.claude/bin/daemon-runner.sh: line 59: log_event: command not found
```

## Solution
Moved the `log_event` function definition to line 41, immediately after directory setup and before any code that might call it.

## Testing
- ✅ Created isolated test environment
- ✅ Installed StarForge
- ✅ Started daemon successfully (PID 884)
- ✅ Created test trigger (senior-engineer → tpm handoff)
- ✅ Daemon detected and processed trigger autonomously
- ✅ Trigger moved to processed/ directory
- ✅ Handoff logged successfully
- ✅ Graceful daemon shutdown

## Files Changed
- `templates/bin/daemon-runner.sh` - Moved log_event function definition before first use

## Discovered During
Daemon simulation testing for MVP v1.0 validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>