### PR TITLE
chore: Bump version to 1.1.0

### DIFF
--- a/templates/VERSION
+++ b/templates/VERSION
@@ -1,13 +1,65 @@
 {
-  "version": "1.0.0",
-  "commit": "c7390ca",
-  "date": "2025-10-26",
+  "version": "1.1.0",
+  "commit": "2ee17ae",
+  "date": "2025-10-28",
   "changelog": [
-    "Initial StarForge release",
-    "Multi-agent development system",
-    "Orchestrator, Senior Engineer, Junior Engineer, QA Engineer, TPM",
-    "Autonomous daemon with trigger-based handoffs",
-    "GitHub integration for issues and PRs"
+    "Real daemon invocation with Claude CLI (replaces simulation)",
+    "Discord integration with auto-setup wizard",
+    "Daemon auto-start on install/update",
+    "Enhanced parallel mode with full Discord notifications",
+    "Version detection and safe migration system",
+    "Settings.json security fixes (project bin/ directories allowed)",
+    "Comprehensive starforge doctor diagnostics",
+    "Daemon status monitoring and lifecycle notifications",
+    "Integration tests for daemon and auto-start",
+    "Portable trigger FIFO sorting (GNU/BSD compatibility)",
+    "Complete daemon documentation in README"
   ],
-  "breaking_changes": []
+  "breaking_changes": [],
+  "new_features": [
+    {
+      "name": "Real Daemon Invocation",
+      "description": "Daemon now invokes real Claude CLI agents instead of simulation",
+      "prs": ["#280", "#281", "#282"]
+    },
+    {
+      "name": "Discord Integration",
+      "description": "Full Discord notification system with auto-setup wizard",
+      "prs": ["#283", "#287"]
+    },
+    {
+      "name": "Daemon Auto-Start",
+      "description": "Daemon automatically starts on install/update",
+      "prs": ["#284", "#288"]
+    },
+    {
+      "name": "Version Detection & Migration",
+      "description": "Safe updates with automatic migration from pre-1.0.0",
+      "prs": ["#255", "#289"]
+    },
+    {
+      "name": "StarForge Doctor",
+      "description": "Comprehensive diagnostics for troubleshooting",
+      "prs": ["#272"]
+    }
+  ],
+  "bug_fixes": [
+    {
+      "description": "Fixed settings.json deny rules blocking project bin/ directories",
+      "pr": "#286"
+    },
+    {
+      "description": "Fixed trigger FIFO sorting for BSD compatibility",
+      "pr": "#277"
+    },
+    {
+      "description": "Fixed daemon log_event function definition order",
+      "pr": "#278"
+    },
+    {
+      "description": "Fixed Claude CLI invocation in daemon-runner",
+      "pr": "#274"
+    }
+  ],
+  "upgrade_notes": "Run 'starforge update' to upgrade. Migration from pre-1.0.0 and 1.0.0 is automatic and non-destructive."
 }


### PR DESCRIPTION
## Summary

Updates `templates/VERSION` from 1.0.0 → 1.1.0 to reflect all features and fixes merged since the initial 1.0.0 release.

## Motivation

**Problem**: The VERSION file still showed 1.0.0 despite 15+ major PRs being merged.

**Impact**: Users running `starforge update` would see incorrect version info, and the migration system wouldn't properly track the current production state.

## Changes

### Version Metadata

**Before:**
```json
{
  "version": "1.0.0",
  "commit": "c7390ca",
  "date": "2025-10-26"
}
```

**After:**
```json
{
  "version": "1.1.0",
  "commit": "2ee17ae",
  "date": "2025-10-28"
}
```

### New Changelog Format

Added structured metadata for better version tracking:
- Detailed changelog (11 major changes)
- `new_features` array with descriptions and PR references
- `bug_fixes` array with PR references
- `upgrade_notes` for users

## Version 1.1.0 Highlights

### 🆕 New Features

1. **Real Daemon Invocation** (#280, #281, #282)
   - Replaced simulation with actual Claude CLI execution
   - Full MCP tool integration via piping

2. **Discord Integration** (#283, #287)
   - Complete notification system (8 event types)
   - Auto-setup wizard integrated into install flow
   - 8 agent channels created automatically

3. **Daemon Auto-Start** (#284, #288)
   - Daemon automatically starts on `starforge install`
   - Daemon automatically restarts on `starforge update`
   - Added `--silent` and `--check-only` flags

4. **Version Detection & Migration** (#255, #289)
   - Safe updates with automatic migration from pre-1.0.0
   - Heuristic detection for installations without VERSION file
   - Non-destructive migrations preserve all user data

5. **StarForge Doctor** (#272)
   - Comprehensive diagnostics (6 validation checks)
   - Actionable error messages with fix commands

### 🐛 Bug Fixes

- Fixed settings.json deny rules blocking project `bin/` directories (#286)
- Fixed trigger FIFO sorting for BSD compatibility (#277)
- Fixed daemon log_event function definition order (#278)
- Fixed Claude CLI invocation in daemon-runner (#274)

### ⚠️ Breaking Changes

**None** - Fully backward compatible with 1.0.0 installations

### 📊 Stats

- **PRs Merged**: 15+ since 1.0.0
- **Lines Changed**: 1000+ additions across daemon, Discord, version detection
- **New Commands**: `starforge setup discord`, `starforge doctor`
- **New Flags**: `--silent`, `--check-only` for daemon

## Testing

- ✅ VERSION file parses correctly with `jq`
- ✅ Commit hash matches latest main (2ee17ae)
- ✅ Date reflects merge date (2025-10-28)
- ✅ All PR references valid

## Upgrade Path

For users on 1.0.0:
```bash
starforge update
```

Migration from 1.0.0 → 1.1.0 is automatic via `migrate_from_1_0_0()`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)