### PR TITLE
fix: Preserve LEARNINGS.md user customizations during updates

### DIFF
--- a/bin/starforge
+++ b/bin/starforge
@@ -963,7 +963,23 @@ case "$COMMAND" in
         fi
 
         # LEARNINGS.md - always safe to update (system file)
-        cp "$STARFORGE_DIR/templates/LEARNINGS.md" "$CLAUDE_DIR/"
+        if [ -f "$CLAUDE_DIR/LEARNINGS.md" ]; then
+            # Check if file has been modified from template
+            if ! diff -q "$STARFORGE_DIR/templates/LEARNINGS.md" "$CLAUDE_DIR/LEARNINGS.md" > /dev/null 2>&1; then
+                # User has customized - preserve and copy new version alongside
+                cp "$STARFORGE_DIR/templates/LEARNINGS.md" "$CLAUDE_DIR/LEARNINGS.md.new"
+                echo -e "${WARN} ${YELLOW}LEARNINGS.md has user customizations - preserved${NC}"
+                echo -e "      ${YELLOW}New template saved as LEARNINGS.md.new for manual merge${NC}"
+            else
+                # Unchanged - safe to update
+                cp "$STARFORGE_DIR/templates/LEARNINGS.md" "$CLAUDE_DIR/"
+                echo -e "${CHECK} Updated LEARNINGS.md"
+            fi
+        else
+            # New installation - just copy
+            cp "$STARFORGE_DIR/templates/LEARNINGS.md" "$CLAUDE_DIR/"
+            echo -e "${CHECK} Added LEARNINGS.md"
+        fi
         echo -e "${CHECK} Updated protocol files"
 
         # Update settings with path replacement


### PR DESCRIPTION
## Summary

Follow-up to PR #289 - Extends file preservation logic to LEARNINGS.md.

## Problem

LEARNINGS.md was being blindly overwritten on `starforge update`, losing project-specific agent learnings accumulated over time. This file contains:
- Project architecture patterns
- API quirks specific to the codebase
- Successful debugging strategies
- Team conventions
- Bug fixes that worked

The file header explicitly says "Cross-cutting learnings that apply to **this project**", indicating it's meant for user customization.

## Solution

Applied the same diff-based preservation logic used for CLAUDE.md:
- Check if file differs from template
- If modified: Preserve original, save new version as `.new`
- If unchanged: Update normally
- Clear user feedback about preservation

## Impact

Both protocol files now preserved:
- ✅ CLAUDE.md - Project instructions, team guidelines
- ✅ LEARNINGS.md - Project-specific agent learnings

Users no longer lose accumulated project knowledge on update.

## Testing

Same testing approach as CLAUDE.md preservation:
1. Modify LEARNINGS.md
2. Run `starforge update`
3. Verify original preserved and `.new` file created

## Related

- Fixes the second half of the file preservation issue
- Discovered during post-merge audit of PR #289
- Thanks to @JediMasterKT for questioning the LEARNINGS.md classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>