### PR TITLE
fix: Address QA review issues in release process docs

### DIFF
--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -28,9 +28,10 @@ git checkout -b chore/update-version-X.Y.Z
 # - Update version number
 # - Update commit hash (get latest: git log -1 --format=%h)
 # - Update date (YYYY-MM-DD)
-# - Add changelog entries
-# - Add new_features array
-# - Add bug_fixes array
+# - Add changelog entries (array of strings)
+# - Update new_features array (objects with name, description, prs)
+# - Update bug_fixes array (objects with description, pr)
+# - Update breaking_changes array (if any)
 # - Update upgrade_notes
 
 # Commit
@@ -168,7 +169,7 @@ gh release view vX.Y.Z
 
 | Version | Date | Commit | Status |
 |---------|------|--------|--------|
-| v1.1.0 | 2025-10-28 | 2ee17ae | Pending (PR #290) |
+| v1.1.0 | 2025-10-28 | 2ee17ae | Released |
 | v1.0.0 | 2025-10-26 | c7390ca | Released |
 
 ## Example: Creating v1.1.0 Release
@@ -243,7 +244,7 @@ jobs:
 Users can check their installed version:
 
 ```bash
-# Check version file
+# Check installed version (deployed from templates/VERSION during install/update)
 cat .claude/STARFORGE_VERSION | jq -r '.version'
 
 # Check latest release
@@ -266,6 +267,10 @@ git tag -a v1.1.1 -m "Hotfix for v1.1.0 issues"
 git push origin v1.1.1
 
 # Or delete bad tag (if caught early)
+# First delete the GitHub Release
+gh release delete v1.1.0 --yes
+
+# Then delete the git tag
 git tag -d v1.1.0
 git push origin :refs/tags/v1.1.0
 ```


### PR DESCRIPTION
## Problem

PR #291 was merged before the QA fixes were included. The 4 QA issues identified in the review are still present in main.

## Solution

This PR applies the fixes that were committed to the `docs/release-process` branch but didn't make it into the merge.

## Issues Fixed

### Issue #1 (P1): VERSION File Field Mismatch
**Lines 31-34**: Updated field descriptions to match actual VERSION structure
- Changed generic "Add new_features array" to "Update new_features array (objects with name, description, prs)"
- Changed "Add bug_fixes array" to "Update bug_fixes array (objects with description, pr)"
- Added "Update breaking_changes array (if any)"

### Issue #2 (P2): Outdated Version Table
**Line 172**: Updated v1.1.0 status from "Pending (PR #290)" to "Released"

### Issue #3 (P1): File Path Clarification
**Line 247**: Added clarifying comment: "(deployed from templates/VERSION during install/update)"

### Issue #4 (P2): Incomplete Rollback Instructions
**Lines 270-275**: Added `gh release delete` step before tag deletion

## Verification

All fixes verified by qa-engineer re-review. No new issues introduced.

## Related

- Original PR: #291
- Fix commit on branch: 00e0f93
- QA review: All 4 issues resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>