### PR TITLE
fix: Add explicit PR merge prohibition to agent definitions

### DIFF
--- a/templates/agents/orchestrator.md
+++ b/templates/agents/orchestrator.md
@@ -54,6 +54,25 @@ echo "================================"
 echo ""
 ```
 
+## ⚠️ CRITICAL: PR Merge Policy
+
+**NEVER merge PRs**. Your role is to:
+1. Monitor PR status (created by junior/senior engineers)
+2. Alert on blockers
+3. **WAIT for human approval to merge**
+
+**Forbidden commands:**
+- `gh pr merge` (any variant)
+- `git push` to main (direct pushes)
+- Creating PRs (that's engineer work)
+
+**Allowed workflow:**
+1. Junior creates PR → QA reviews → You monitor
+2. If approved: Note it in status check
+3. **Human decides when to merge**
+
+**Rationale**: Merging is a human decision point. Agents optimize for velocity, humans optimize for stability.
+
 ## Core Loop
 
 **Run every 15 minutes or when triggered:**

--- a/templates/agents/qa-engineer.md
+++ b/templates/agents/qa-engineer.md
@@ -134,6 +134,35 @@ echo ""
 
 ## PR Review Process
 
+## ⚠️ CRITICAL: Review Process & PR Tagging
+
+### After Review, ALWAYS Tag PRs
+
+**If APPROVED:**
+```bash
+gh pr edit <PR-NUMBER> --add-label "qa-approved"
+```
+
+**If CHANGES REQUESTED:**
+```bash
+gh pr edit <PR-NUMBER> --add-label "qa-declined"
+```
+
+### What You DON'T Do
+
+**FORBIDDEN: Never merge PRs**
+- `gh pr merge` is STRICTLY PROHIBITED
+- Your verdict is advisory only
+- Human makes final merge decision
+
+**Workflow after tagging:**
+1. Post review comment with verdict
+2. Add appropriate label (qa-approved/qa-declined)
+3. Create trigger for orchestrator (if needed)
+4. **STOP** - wait for human to merge
+
+**Human decides**: When to deploy, risk tolerance, rollback strategy.
+
 ### Step 1: Select PR to Review
 
 ```bash


### PR DESCRIPTION
## Problem

With branch protection removed (to allow PR author self-merge), we need agent-level enforcement to prevent agents from merging PRs.

**Root Issue**: 
- User cannot approve their own PRs with branch protection enabled
- But we don't want agents (orchestrator/qa-engineer) merging PRs autonomously
- Solution: Remove GitHub-level protection, add agent-instruction-level prohibition

## Changes

### 1. Orchestrator Agent (`templates/agents/orchestrator.md`)

**Added Section**: "⚠️ CRITICAL: PR Merge Policy" (after line 56)

**Key Points**:
- **FORBIDDEN**: `gh pr merge` (any variant), `git push` to main, Creating PRs
- **ALLOWED**: Monitor PR status, alert on blockers, wait for human approval
- **RATIONALE**: "Agents optimize for velocity, humans optimize for stability"

**Workflow**:
1. Junior creates PR → QA reviews → Orchestrator monitors
2. If approved: Note it in status check
3. **Human decides when to merge**

### 2. QA Engineer Agent (`templates/agents/qa-engineer.md`)

**Added Section**: "⚠️ CRITICAL: Review Process & PR Tagging" (after line 135)

**Key Points**:
- **MANDATORY**: After every review, tag PR with `qa-approved` or `qa-declined`
- **FORBIDDEN**: `gh pr merge` is STRICTLY PROHIBITED
- **ROLE**: Verdict is advisory only, human makes final merge decision

**Workflow**:
1. Post review comment with verdict
2. Add appropriate label (qa-approved/qa-declined)
3. Create trigger for orchestrator (if needed)
4. **STOP** - wait for human to merge

## Why Agent-Level Enforcement?

**Human Decision Points**:
- Deployment timing (merge when ready to deploy)
- Risk tolerance (P0 vs P2, size of changes)
- Rollback strategy (do we have rollback plan?)
- Integration coordination (waiting for dependent PRs?)

**Agent Optimization**:
- Velocity (merge ASAP to clear queue)
- Throughput (more PRs merged = higher velocity)
- Queue management (blocked on unmerged PRs)

**Conflict**: Agent incentives don't align with deployment stability. Human must decide.

## Testing

- ✅ Orchestrator definition includes explicit merge prohibition
- ✅ QA-engineer definition includes explicit merge prohibition + mandatory tagging
- ✅ Both agents have clear workflow showing "human decides" step
- ✅ Instructions use FORBIDDEN/MANDATORY language for clarity

## Related Issues

- Fixes process gap from PR #291 (merged before re-review)
- Complements v1.1.0 release process improvements
- Aligns with UX vision: agents assist, humans decide

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>