### PR TITLE
fix: Remove line break in starforge update version detection

### DIFF
--- a/bin/starforge
+++ b/bin/starforge
@@ -881,8 +881,7 @@ case "$COMMAND" in
         # Get latest version
         LATEST_VERSION="unknown"
         if [ -f "$STARFORGE_DIR/templates/VERSION" ]; then
-            LATEST_VERSION=$(jq -r '.version // "unknown"' "$STARFORGE_DIR/templates/VERSION" 2>/dev/null || echo
-"unknown")
+            LATEST_VERSION=$(jq -r '.version // "unknown"' "$STARFORGE_DIR/templates/VERSION" 2>/dev/null || echo "unknown")
         fi
 
         echo "   Installed: $INSTALLED_VERSION"


### PR DESCRIPTION
## Summary

Fixes critical line break bug in `bin/starforge` line 884-885.

## Problem

```bash
LATEST_VERSION=$(jq ... || echo
"unknown")  # Line break here causes error
```

Bash tries to execute "unknown" as a command.

## Solution

```bash
LATEST_VERSION=$(jq ... || echo "unknown")  # Fixed - all on one line
```

## Files Changed

- `bin/starforge` (1 line changed)

## Testing

✅ Syntax validated
✅ No other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)