### PR TITLE
fix: Copy lib files during starforge update (Issue #323)

### DIFF
--- a/bin/starforge
+++ b/bin/starforge
@@ -946,6 +946,12 @@ case "$COMMAND" in
         chmod +x "$CLAUDE_DIR/bin"/*
         echo -e "${CHECK} Updated bin scripts"
 
+        # Update library files
+        echo -e "${INFO}Updating library files..."
+        cp "$STARFORGE_DIR/templates/lib"/*.sh "$CLAUDE_DIR/lib/"
+        chmod +x "$CLAUDE_DIR/lib"/*.sh
+        echo -e "${CHECK} Updated library files"
+
         # Update protocol files
         echo -e "${INFO}Updating protocol files..."
         
@@ -1024,6 +1030,7 @@ case "$COMMAND" in
         echo -e "${YELLOW}Updated components:${NC}"
         echo "  - 5 agent definitions (orchestrator, senior-engineer, junior-engineer, qa-engineer, tpm-agent)"
         echo "  - Scripts (trigger-monitor, trigger-helpers, watch-triggers)"
+        echo "  - Library files (19 shared helpers: discord-notify, compensation, event-log, lock-helpers, etc.)"
         echo "  - Hooks (block-main-edits, block-main-bash, stop.py with Discord integration)"
         echo "  - Bin scripts (daemon, daemon-runner)"
         echo "  - Protocol files (CLAUDE.md, LEARNINGS.md)"


### PR DESCRIPTION
## Summary

Fixes critical bug where `starforge update` was not copying library files from `templates/lib/` to `.claude/lib/`, breaking all agent functionality.

## Problem

After running `starforge update`:
- All 19 `.claude/lib/*.sh` files were missing
- Agents could not function (missing `discord-notify.sh`, `compensation.sh`, `event-log.sh`, `lock-helpers.sh`, etc.)
- `starforge doctor` reported installation broken
- Users had to manually re-install to fix

## Root Cause

The `update` command in `bin/starforge` copied:
- ✅ Agents (`templates/agents/*.md`)
- ✅ Scripts (`templates/scripts/*.sh`)
- ✅ Hooks (`templates/hooks/*`)
- ✅ Bin files (`templates/bin/*.sh`)
- ❌ **Library files (MISSING)**

The `install` command correctly copied lib files, but `update` did not.

## Solution

Added lib file copying logic to the update command:

```bash
# Update library files
echo -e "${INFO}Updating library files..."
cp "$STARFORGE_DIR/templates/lib"/*.sh "$CLAUDE_DIR/lib/"
chmod +x "$CLAUDE_DIR/lib"/*.sh
echo -e "${CHECK} Updated library files"
```

**Placement:** After bin scripts update (line 947), before protocol files update (line 955)

## Changes

**File:** `bin/starforge`

1. **Lines 949-953:** Added lib file copy block
2. **Line 1033:** Updated completion message to mention lib files

**Total:** 7 lines added (5 for copy logic, 1 for completion message, 1 blank line)

## Test Plan

### Before Fix
```bash
starforge update
ls .claude/lib/*.sh 2>/dev/null | wc -l
# Output: 0 (bug confirmed)
```

### After Fix
```bash
starforge update
ls .claude/lib/*.sh | wc -l
# Output: 19 (bug fixed)

diff -r templates/lib .claude/lib
# No differences (all files copied)

ls -la .claude/lib/*.sh | grep -v 'rwx'
# Empty (all executable)

starforge doctor
# All checks pass
```

## Impact

- ✅ **Fixes broken agent functionality** after update
- ✅ **No breaking changes** (only adds missing functionality)
- ✅ **Backwards compatible** (safe for all users)
- ✅ **Follows existing patterns** (matches install command logic)

## Completion Message Output

Users will now see:
```
Updated components:
  - 5 agent definitions (orchestrator, senior-engineer, junior-engineer, qa-engineer, tpm-agent)
  - Scripts (trigger-monitor, trigger-helpers, watch-triggers)
  - Library files (19 shared helpers: discord-notify, compensation, event-log, lock-helpers, etc.)
  - Hooks (block-main-edits, block-main-bash, stop.py with Discord integration)
  - Bin scripts (daemon, daemon-runner)
  - Protocol files (CLAUDE.md, LEARNINGS.md)
  - Settings (settings.json)
```

## Closes

Closes #323

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>